### PR TITLE
Removed Grid Based Movement

### DIFF
--- a/Assets/Scripts/Player/PlayerControl.cs
+++ b/Assets/Scripts/Player/PlayerControl.cs
@@ -114,37 +114,8 @@ public class PlayerControl : MonoBehaviour
 
             }
 
-            //isMoving = false;
-            //animator.SetBool("isMoving",isMoving);
             PromptCheck();
 
-
-            /*
-            if (input != Vector2.zero)
-            {   
-                animator.SetFloat("moveX", input.x);
-                animator.SetFloat("moveY", input.y);
-                var targetPos = transform.position; // current position of the player
-
-                if (Input.GetKey(KeyCode.LeftShift))
-                {
-                    isSprinting = true;
-                }
-                else
-                {
-                    isSprinting = false;
-                }
-
-                targetPos.x += input.x;
-                targetPos.y += input.y;
-                PromptCheck();
-
-                if (IsWalkable(targetPos))
-                    StartCoroutine(Move(targetPos));
-                
-            }
-            */
-            //animator.SetBool("isMoving", isMoving);
 
             if(Input.GetKeyDown(KeyCode.Space) || Input.GetMouseButtonDown(0))
             {
@@ -210,30 +181,6 @@ public class PlayerControl : MonoBehaviour
             activePrompt.GetComponent<Interactable>()?.HidePrompt();
             activePrompt = null;
         }
-    }
-
-    IEnumerator Move(Vector3 targetPos)
-    {
-        isMoving = true;
-        HidePrompt();
-        moveCoroutine = StartCoroutine(MoveCoroutine(targetPos)); // Store the coroutine reference
-        yield return moveCoroutine; // Wait for the coroutine to finish
-    }
-
-    private IEnumerator MoveCoroutine(Vector3 targetPos)
-    {
-        while ((targetPos - transform.position).sqrMagnitude > Mathf.Epsilon) 
-        {
-            float currentSpeed = isSprinting ? moveSpeed * 2.0f : moveSpeed;
-            transform.position = Vector3.MoveTowards(transform.position, targetPos, currentSpeed * Time.deltaTime);
-            yield return null;
-        }
-        transform.position = targetPos;
-        isMoving = false;
-
-        CheckForEncounters();
-        PromptCheck();
-
     }
 
     private bool IsWalkable(Vector3 targetPos)


### PR DESCRIPTION
Removed grid based movement logic from playercontrol.cs. The player can now move more fluidly and no longer has to move in full increments of tiles, a design decision made by the previous group that created the perception of an input delay.

- player movement no longer entirely grid-based
- movement function is no longer a coroutine. removed move() and movementcoroutine() functions because they are now obsolete
- retuned the encounter rate since the encounter rate calculation was based on it being done on every tile rather than every x-y point in the scene. still probably needs to be tuned a bit more.