### PR TITLE
Small Change: added WASD controls to dialogue options

### DIFF
--- a/Assets/Scripts/Dialog/ChoiceBox.cs
+++ b/Assets/Scripts/Dialog/ChoiceBox.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Security.Cryptography;
 using UnityEngine;
 
 public class ChoiceBox : MonoBehaviour


### PR DESCRIPTION
- made this change because it is more intuitive. the users can move the player using either WASD or the arrow keys, the users should be able to use either option for dialogue as well.
- added the ability to select dialogue options by pressing W and S in addition to the up and down arrows
- tested by opening up the ai rival dialogue menu