### PR TITLE
can select dialogue options with W and S

### DIFF
--- a/Assets/Scripts/Dialog/ChoiceBox.cs
+++ b/Assets/Scripts/Dialog/ChoiceBox.cs
@@ -42,9 +42,9 @@ public class ChoiceBox : MonoBehaviour
 
     private void Update()
     {
-        if (Input.GetKeyDown(KeyCode.DownArrow))
+        if (Input.GetKeyDown(KeyCode.DownArrow)|| Input.GetKeyDown(KeyCode.S))
             ++currentChoice;
-        else if (Input.GetKeyDown(KeyCode.UpArrow))
+        else if (Input.GetKeyDown(KeyCode.UpArrow)|| Input.GetKeyDown(KeyCode.W))
             --currentChoice;
         currentChoice = Mathf.Clamp(currentChoice, 0, choiceTexts.Count - 1);
 


### PR DESCRIPTION
- you can now select options in the dialogue box using W and S.
- tested it by just opening up the ai rival dialogue box
- reopened this pr because there was another pharmacy go directory nested within the main directory. this doesn't have it