### PR TITLE
Fixed Scene Index Conflict with Murder Mystery and Leaderboard

### DIFF
--- a/Assets/Scripts/Menus/MainMenu.cs
+++ b/Assets/Scripts/Menus/MainMenu.cs
@@ -12,7 +12,7 @@ public class MainMenu : MonoBehaviour
     // Loads level structure and manager for the menu functions
 
     private const int HUB_SCENE_INDEX = 7;
-    private const int LEADERBOARD_SCENE_INDEX=16;
+    private const int LEADERBOARD_SCENE_INDEX=17; //changed to resolve a conflict with the murder mystery scene
     private const string MASTER_VOLUME_KEY = "masterVolume";
     private const int DEfAULT_VOLUME_VALUE = 10;
     public AudioMixer audioMixer;

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -57,11 +57,11 @@ EditorBuildSettings:
     path: Assets/Scenes/Main Levels/Level 4.unity
     guid: 5571c117d26b03e40878ca9c0da18236
   - enabled: 1
-    path: Assets/Scenes/Main Levels/LeaderBoard.unity
-    guid: f386612c381cef0449e2a2565257cf90
-  - enabled: 1
     path: Assets/Scenes/Main Levels/Murder Mystery.unity
     guid: 92834e4257b4e0a4d9ee42dcf064cde1
+  - enabled: 1
+    path: Assets/Scenes/Main Levels/Leaderboard.unity
+    guid: f386612c381cef0449e2a2565257cf90
   m_configObjects:
     com.unity.input.settings.actions: {fileID: -944628639613478452, guid: 2bcd2660ca9b64942af0de543d8d7100, type: 3}
   m_UseUCBPForAssetBundles: 0


### PR DESCRIPTION
Fixed the bug that was causing issues when loading the leaderboard and the murder mystery scenes. 

Since Nick and I worked on both of these new scenes independently at same time, we both made it so that the indices for the leaderboard and the murder mystery scenes was 16

- when I reconciled the merge conflict intially, it lead to murder mystery being set to index 17. The portals for the murder mystery were set up so it would change the scene to the scene at index 16, which was the murder mystery in Nick's initial commit, but then was changed so it opened the leaderboard instead.
- went into the build profile and changed the scene build order to murder mystery was at index 16 and the leaderboard was at index 17
- decided to do it like this because all i needed to do to fix it was to change one hard-coded const value in mainmenu.cs as opposed to changing the scene index for the murder mystery portals.
