### PR TITLE
Small Changes: Battle Loss Rebalance / Leaderboard Population

### DIFF
--- a/Assets/Scripts/Battle/BattleSystem.cs
+++ b/Assets/Scripts/Battle/BattleSystem.cs
@@ -527,9 +527,15 @@ public class BattleSystem : MonoBehaviour
                     hudController.ExitingBattle();
                     yield break;
                 }
+                //don't penalize the player as heavily if they get the majority of the questions right 
+                else if(questionsRight > maxBattleQuestions/2){
+                    
+                    yield return StartCoroutine(dialogBox.TypeDialog("You missed some questions. Don't give up!"));
+
+                }
                 else
                 {
-                    yield return StartCoroutine(dialogBox.TypeDialog("You missed some questions. Better luck next time!"));
+                    yield return StartCoroutine(dialogBox.TypeDialog("You got most of the questions wrong. Better luck next time!"));
                     CoinManager.Instance.RemoveCoin(3);
 
                     if(CoinManager.Instance.GetCoinCount() >= 3)

--- a/Assets/Scripts/Leaderboard/LeaderboardManager.cs
+++ b/Assets/Scripts/Leaderboard/LeaderboardManager.cs
@@ -77,7 +77,7 @@ public class LeaderBoardManager : MonoBehaviour
         try
         {
             leaderboardScoresPage =
-                await LeaderboardsService.Instance.GetScoresAsync(leaderboardID);
+                await LeaderboardsService.Instance.GetScoresAsync(leaderboardID, new GetScoresOptions {Limit = 100});
         }
         //throw an error if that fails for some reason or another
         catch (System.Exception e)


### PR DESCRIPTION
A bundle of two small fixes that I made to the game.

- I decided to rebalance the penalty for losing a battle. If the player gets a majority of the questions an NPC asks correct, but not all of them, they will still not receive any coins, but they won't lose any.
- When writing the leaderboard code initially, I did not realize by default, the call to the unity leaderboard API only returns the top 10 results from the leaderboard. I upped it to 100 for now, I will make a more future proof implementation in the future.