### PR TITLE
Small Quality of Life Improvements

### DIFF
--- a/Assets/Scenes/Main Levels/Hub.unity
+++ b/Assets/Scenes/Main Levels/Hub.unity
@@ -323236,7 +323236,7 @@ MonoBehaviour:
     - Thanks a bunch!
   InteractPrompt: {fileID: 55869294}
   seen: 0
-  showTravelChoice: 1
+  showTravelChoice: 0
   travelChoices:
   - Yes
   - No

--- a/Assets/Scenes/Main Levels/Hub.unity
+++ b/Assets/Scenes/Main Levels/Hub.unity
@@ -303492,7 +303492,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -436.25787, y: -21.1171}
+  m_AnchoredPosition: {x: -436.2578, y: -21.117126}
   m_SizeDelta: {x: -872.5057, y: -656.4055}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1497186944
@@ -358857,7 +358857,7 @@ MonoBehaviour:
   questionUnit: {fileID: 394439894}
   hudController: {fileID: 1497186944}
   levelCompletePanel: {fileID: 1094782297}
-  timeLimit: 15
+  timeLimit: 30
 --- !u!4 &2127978722
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Battle/BattleSystem.cs
+++ b/Assets/Scripts/Battle/BattleSystem.cs
@@ -582,12 +582,12 @@ public class BattleSystem : MonoBehaviour
     private Coroutine rivalTimer;
     private IEnumerator BattleTimer(float duration)
     {
-        Debug.Log("duration 1 == " + duration); 
+        //Debug.Log("duration 1 == " + duration); 
         float elaspedTime = 0f;
         while (elaspedTime < duration && state == BattleState.PLAYERANSWER)
         {            
-            Debug.Log("elapsed time == " + elaspedTime);
-            Debug.Log("duration == " + duration); 
+            //Debug.Log("elapsed time == " + elaspedTime);
+            //Debug.Log("duration == " + duration); 
             elaspedTime += Time.deltaTime;
             yield return null;
         }

--- a/Assets/Scripts/Battle/BattleSystem.cs
+++ b/Assets/Scripts/Battle/BattleSystem.cs
@@ -18,7 +18,7 @@ public class BattleSystem : MonoBehaviour
     [SerializeField] private QuestionUnit questionUnit;
     [SerializeField] private HudController hudController;
     [SerializeField] private GameObject levelCompletePanel;
-    [SerializeField] private float timeLimit = 30f;
+    [SerializeField] private float timeLimit = 60f;
 
     public event Action<bool> OnBattleOver;
 

--- a/Assets/Scripts/Battle/BattleSystem.cs
+++ b/Assets/Scripts/Battle/BattleSystem.cs
@@ -582,6 +582,7 @@ public class BattleSystem : MonoBehaviour
     private Coroutine rivalTimer;
     private IEnumerator BattleTimer(float duration)
     {
+        Debug.Log("duration 1 == " + duration); 
         float elaspedTime = 0f;
         while (elaspedTime < duration && state == BattleState.PLAYERANSWER)
         {            

--- a/Assets/Scripts/Battle/BattleSystem.cs
+++ b/Assets/Scripts/Battle/BattleSystem.cs
@@ -18,7 +18,7 @@ public class BattleSystem : MonoBehaviour
     [SerializeField] private QuestionUnit questionUnit;
     [SerializeField] private HudController hudController;
     [SerializeField] private GameObject levelCompletePanel;
-    [SerializeField] private float timeLimit = 60f;
+    [SerializeField] private float timeLimit = 30f;
 
     public event Action<bool> OnBattleOver;
 
@@ -272,6 +272,7 @@ public class BattleSystem : MonoBehaviour
             // Start the rival timer - For timeout usage
             if (rivalTimer == null)
             {
+                Debug.Log("time limit == " + timeLimit);
                 rivalTimer = StartCoroutine(BattleTimer(timeLimit));
             }
         }
@@ -444,7 +445,7 @@ public class BattleSystem : MonoBehaviour
             }
             else if (source == AnswerSource.Timeout)
             {
-                yield return StartCoroutine(dialogBox.TypeDialog("Time's up, you failed!"));
+                yield return StartCoroutine(dialogBox.TypeDialog("Time's up, better luck next time!"));
             }
             else
             {
@@ -583,7 +584,9 @@ public class BattleSystem : MonoBehaviour
     {
         float elaspedTime = 0f;
         while (elaspedTime < duration && state == BattleState.PLAYERANSWER)
-        {
+        {            
+            Debug.Log("elapsed time == " + elaspedTime);
+            Debug.Log("duration == " + duration); 
             elaspedTime += Time.deltaTime;
             yield return null;
         }
@@ -592,6 +595,7 @@ public class BattleSystem : MonoBehaviour
         if (state == BattleState.PLAYERANSWER)
         {
             Debug.Log("Times up, you lose!");
+            Debug.Log("elapsed time == " + elaspedTime);
             timedOut = true;
             // Stop AI routine if it's still running
             if (aiAnswerRoutine != null)

--- a/Assets/Scripts/Dialog/DialogManager.cs
+++ b/Assets/Scripts/Dialog/DialogManager.cs
@@ -63,10 +63,6 @@ public class DialogManager : MonoBehaviour
         }
 
         OnDialogFinished?.Invoke();
-        /*
-        dialogBox.SetActive(false);
-        IsShowing = false;
-        */
     }
 
     // Standardized Close dialog

--- a/Assets/Scripts/Dialog/DialogManager.cs
+++ b/Assets/Scripts/Dialog/DialogManager.cs
@@ -129,8 +129,6 @@ public class DialogManager : MonoBehaviour
     public IEnumerator TypeDialog(string line)
     {
         // TypeDialog calls now wait until the call returns to before resuming other functions
-        //fastDialog = Input.GetKey(KeyCode.LeftShift);
-        Debug.Log("fast dialog mode");
         dialogText.text = "";
         foreach (var letter in line.ToCharArray())
         {            
@@ -138,7 +136,6 @@ public class DialogManager : MonoBehaviour
             dialogText.text += letter;
             if (fastDialog)
             {
-                Debug.Log("fast");
                 yield return new WaitForSeconds(0.33f / letterPerSecond);
             }
             else

--- a/Assets/Scripts/Dialog/DialogManager.cs
+++ b/Assets/Scripts/Dialog/DialogManager.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.InputSystem;
 using UnityEngine.UI;
 
 public class DialogManager : MonoBehaviour
@@ -16,6 +17,7 @@ public class DialogManager : MonoBehaviour
     
     public event Action OnShowDialog;
     public event Action OnDialogFinished;
+    bool fastDialog;
 
     public static DialogManager Instance { get; private set; }
     private void Awake()
@@ -127,11 +129,22 @@ public class DialogManager : MonoBehaviour
     public IEnumerator TypeDialog(string line)
     {
         // TypeDialog calls now wait until the call returns to before resuming other functions
+        //fastDialog = Input.GetKey(KeyCode.LeftShift);
+        Debug.Log("fast dialog mode");
         dialogText.text = "";
         foreach (var letter in line.ToCharArray())
-        {
+        {            
+            fastDialog = Input.GetKey(KeyCode.LeftShift);
             dialogText.text += letter;
-            yield return new WaitForSeconds(1f / letterPerSecond);
+            if (fastDialog)
+            {
+                Debug.Log("fast");
+                yield return new WaitForSeconds(0.33f / letterPerSecond);
+            }
+            else
+            {
+                yield return new WaitForSeconds(1f / letterPerSecond);
+            }
         }
         
     }


### PR DESCRIPTION
Made a couple of quality of life improvements to the game

- you are now able to speed up dialog by holding the left shift key when the text is scrolling. the text speed as it existed before was driving me b-a-n-a-n-a-s.
- extended the battle time out from 15 seconds to 30 minutes in response to feedback from the players. Should help make things less challenging for new players.