### PR TITLE
Restoring Quality of Life Fixes from PR #95

### DIFF
--- a/Assets/Scenes/Main Levels/Hub.unity
+++ b/Assets/Scenes/Main Levels/Hub.unity
@@ -349901,7 +349901,7 @@ MonoBehaviour:
   questionUnit: {fileID: 394439894}
   hudController: {fileID: 1497186944}
   levelCompletePanel: {fileID: 1094782297}
-  timeLimit: 15
+  timeLimit: 30
 --- !u!4 &2127978722
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Main Levels/Main Menu.unity
+++ b/Assets/Scenes/Main Levels/Main Menu.unity
@@ -1524,7 +1524,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: 'Version 2.0 '
+  m_text: Version 2.1
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}

--- a/Assets/Scripts/Battle/BattleSystem.cs
+++ b/Assets/Scripts/Battle/BattleSystem.cs
@@ -272,6 +272,7 @@ public class BattleSystem : MonoBehaviour
             // Start the rival timer - For timeout usage
             if (rivalTimer == null)
             {
+                Debug.Log("time limit == " + timeLimit);
                 rivalTimer = StartCoroutine(BattleTimer(timeLimit));
             }
         }
@@ -444,7 +445,7 @@ public class BattleSystem : MonoBehaviour
             }
             else if (source == AnswerSource.Timeout)
             {
-                yield return StartCoroutine(dialogBox.TypeDialog("Time's up, you failed!"));
+                yield return StartCoroutine(dialogBox.TypeDialog("Time's up, better luck next time!"));
             }
             else
             {
@@ -527,15 +528,9 @@ public class BattleSystem : MonoBehaviour
                     hudController.ExitingBattle();
                     yield break;
                 }
-                //don't penalize the player as heavily if they get the majority of the questions right 
-                else if(questionsRight > maxBattleQuestions/2){
-                    
-                    yield return StartCoroutine(dialogBox.TypeDialog("You missed some questions. Don't give up!"));
-
-                }
                 else
                 {
-                    yield return StartCoroutine(dialogBox.TypeDialog("You got most of the questions wrong. Better luck next time!"));
+                    yield return StartCoroutine(dialogBox.TypeDialog("You missed some questions. Better luck next time!"));
                     CoinManager.Instance.RemoveCoin(3);
 
                     if(CoinManager.Instance.GetCoinCount() >= 3)
@@ -587,9 +582,12 @@ public class BattleSystem : MonoBehaviour
     private Coroutine rivalTimer;
     private IEnumerator BattleTimer(float duration)
     {
+        //Debug.Log("duration 1 == " + duration); 
         float elaspedTime = 0f;
         while (elaspedTime < duration && state == BattleState.PLAYERANSWER)
-        {
+        {            
+            //Debug.Log("elapsed time == " + elaspedTime);
+            //Debug.Log("duration == " + duration); 
             elaspedTime += Time.deltaTime;
             yield return null;
         }
@@ -598,6 +596,7 @@ public class BattleSystem : MonoBehaviour
         if (state == BattleState.PLAYERANSWER)
         {
             Debug.Log("Times up, you lose!");
+            Debug.Log("elapsed time == " + elaspedTime);
             timedOut = true;
             // Stop AI routine if it's still running
             if (aiAnswerRoutine != null)
@@ -736,4 +735,3 @@ public class BattleSystem : MonoBehaviour
 
 
 }
-

--- a/Assets/Scripts/Dialog/DialogManager.cs
+++ b/Assets/Scripts/Dialog/DialogManager.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.InputSystem;
 using UnityEngine.UI;
 
 public class DialogManager : MonoBehaviour
@@ -16,6 +17,7 @@ public class DialogManager : MonoBehaviour
     
     public event Action OnShowDialog;
     public event Action OnDialogFinished;
+    bool fastDialog;
 
     public static DialogManager Instance { get; private set; }
     private void Awake()
@@ -61,10 +63,6 @@ public class DialogManager : MonoBehaviour
         }
 
         OnDialogFinished?.Invoke();
-        /*
-        dialogBox.SetActive(false);
-        IsShowing = false;
-        */
     }
 
     // Standardized Close dialog
@@ -129,9 +127,17 @@ public class DialogManager : MonoBehaviour
         // TypeDialog calls now wait until the call returns to before resuming other functions
         dialogText.text = "";
         foreach (var letter in line.ToCharArray())
-        {
+        {            
+            fastDialog = Input.GetKey(KeyCode.LeftShift);
             dialogText.text += letter;
-            yield return new WaitForSeconds(1f / letterPerSecond);
+            if (fastDialog)
+            {
+                yield return new WaitForSeconds(0.33f / letterPerSecond);
+            }
+            else
+            {
+                yield return new WaitForSeconds(1f / letterPerSecond);
+            }
         }
         
     }


### PR DESCRIPTION
During my misadventure last week when I messed up the merge, I realized that I accidentally undid my merge for the pull request that included these pull requests. Here is the text from the original PR: https://github.com/LucyCheng111/PharmacyGO/pull/95

Made a couple of quality of life improvements to the game
- you are now able to speed up dialog by holding the left shift key when the text is scrolling. the text speed as it existed before was driving me b-a-n-a-n-a-s.
- extended the battle time out from 15 seconds to 30 minutes in response to feedback from the players. Should help make things less challenging for new players.
