### PR TITLE
Rollback fixes 1

### DIFF
--- a/Assets/Prefabs/Customizable NPC.prefab
+++ b/Assets/Prefabs/Customizable NPC.prefab
@@ -77,7 +77,7 @@ SpriteRenderer:
   m_SortingLayer: 3
   m_SortingOrder: 0
   m_Sprite: {fileID: -3948168425033643615, guid: 66124f851f40d5848ab1fe89a5944c25, type: 3}
-  m_Color: {r: 1, g: 0.85586596, b: 0.6933962, a: 1}
+  m_Color: {r: 0.2924528, g: 0.20672962, b: 0.111739054, a: 1}
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 0
@@ -363,8 +363,12 @@ MonoBehaviour:
   - Yes
   - No
   minigameChoices: []
+  getProgressionItemDialog:
+    lines: []
   yesChoiceInt: 0
   cantaffordtravelDialog:
+    lines: []
+  TravelIsFreeDialog:
     lines: []
 --- !u!1 &7009065552369045641
 GameObject:

--- a/Assets/Prefabs/UI Components/Minigames/WordPlaceholder.prefab
+++ b/Assets/Prefabs/UI Components/Minigames/WordPlaceholder.prefab
@@ -1,0 +1,144 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &8578645253295158001
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7612698496868358006}
+  - component: {fileID: 7723673193822220407}
+  - component: {fileID: 5943797642284066792}
+  - component: {fileID: 6440315291256267441}
+  - component: {fileID: 3439430138916747593}
+  m_Layer: 5
+  m_Name: WordPlaceholder
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7612698496868358006
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8578645253295158001}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -253.01205, y: 168.98883}
+  m_SizeDelta: {x: 140, y: 90}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7723673193822220407
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8578645253295158001}
+  m_CullTransparentMesh: 1
+--- !u!114 &5943797642284066792
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8578645253295158001}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.18867922, g: 0.18867922, b: 0.18867922, a: 0.8}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 7ef9774e3c0bf9a4bbf48547a6c1a91c, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &6440315291256267441
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8578645253295158001}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a74a81c7ed181134e991417a3dab0833, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  word: 
+  text: {fileID: 0}
+  lastLocation: {fileID: 0}
+  Facade: {fileID: 0}
+  indexInSentence: -1
+  indexInWords: 0
+  beingDragged: 0
+--- !u!61 &3439430138916747593
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8578645253295158001}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 1.9851074, y: -2.8535461}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 141.93958, y: 94.049866}
+  m_EdgeRadius: 0

--- a/Assets/Prefabs/UI Components/Minigames/WordPlaceholder.prefab.meta
+++ b/Assets/Prefabs/UI Components/Minigames/WordPlaceholder.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 53b63535a81d5af45baa1b76920c5749
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/Main Levels/Hub.unity
+++ b/Assets/Scenes/Main Levels/Hub.unity
@@ -177287,6 +177287,78 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &333548345
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 333548346}
+  - component: {fileID: 333548348}
+  - component: {fileID: 333548347}
+  m_Layer: 5
+  m_Name: Image Display
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &333548346
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 333548345}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1123438582}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 613, y: 283}
+  m_SizeDelta: {x: 475.188, y: 278.219}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &333548347
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 333548345}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1344c3c82d62a2a41a3576d8abb8e3ea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Texture: {fileID: 0}
+  m_UVRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+--- !u!222 &333548348
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 333548345}
+  m_CullTransparentMesh: 1
 --- !u!1 &335432713
 GameObject:
   m_ObjectHideFlags: 0
@@ -261510,6 +261582,18 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1820392072}
     m_Modifications:
+    - target: {fileID: 3174206043724567575, guid: c252e9b57effb6d49b0df765079fb9a7, type: 3}
+      propertyPath: ImageDisplay
+      value: 
+      objectReference: {fileID: 333548345}
+    - target: {fileID: 3174206043724567575, guid: c252e9b57effb6d49b0df765079fb9a7, type: 3}
+      propertyPath: correctnessPopup
+      value: 
+      objectReference: {fileID: 1723799542}
+    - target: {fileID: 3174206043724567575, guid: c252e9b57effb6d49b0df765079fb9a7, type: 3}
+      propertyPath: placeholderObject
+      value: 
+      objectReference: {fileID: 8578645253295158001, guid: 53b63535a81d5af45baa1b76920c5749, type: 3}
     - target: {fileID: 5993240195274942701, guid: c252e9b57effb6d49b0df765079fb9a7, type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
@@ -261590,18 +261674,37 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 7690039836488619218, guid: c252e9b57effb6d49b0df765079fb9a7, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 8009683466092053363, guid: c252e9b57effb6d49b0df765079fb9a7, type: 3}
       propertyPath: m_Name
       value: Minigames
       objectReference: {fileID: 0}
+    - target: {fileID: 8971456928744567732, guid: c252e9b57effb6d49b0df765079fb9a7, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
-    m_AddedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 6632969046395784530, guid: c252e9b57effb6d49b0df765079fb9a7, type: 3}
+      insertIndex: 2
+      addedObject: {fileID: 1723799541}
+    - targetCorrespondingSourceObject: {fileID: 6632969046395784530, guid: c252e9b57effb6d49b0df765079fb9a7, type: 3}
+      insertIndex: 3
+      addedObject: {fileID: 333548346}
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c252e9b57effb6d49b0df765079fb9a7, type: 3}
 --- !u!224 &1123438581 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 5993240195274942701, guid: c252e9b57effb6d49b0df765079fb9a7, type: 3}
+  m_PrefabInstance: {fileID: 1123438580}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &1123438582 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 6632969046395784530, guid: c252e9b57effb6d49b0df765079fb9a7, type: 3}
   m_PrefabInstance: {fileID: 1123438580}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &1124113139
@@ -325122,6 +325225,142 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 5511220477222073332, guid: 6a0f26c1865828e4fa2ff99b2e488e16, type: 3}
   m_PrefabInstance: {fileID: 1707148766}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1723799540
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1723799541}
+  - component: {fileID: 1723799543}
+  - component: {fileID: 1723799542}
+  m_Layer: 5
+  m_Name: Correctness Popup
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &1723799541
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1723799540}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1123438582}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 648.93, y: -233}
+  m_SizeDelta: {x: 297.8609, y: 111.3564}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1723799542
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1723799540}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: b828f5f19884e7948ae39651293b870d, type: 2}
+  m_sharedMaterial: {fileID: -901149219012016657, guid: b828f5f19884e7948ae39651293b870d, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 0.959195, b: 0, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1723799543
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1723799540}
+  m_CullTransparentMesh: 1
 --- !u!1 &1737810379
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Main Levels/Hub.unity
+++ b/Assets/Scenes/Main Levels/Hub.unity
@@ -176907,6 +176907,7 @@ MonoBehaviour:
   - ShepardsGlasses
   - MedicalSupplies
   - IDCard
+  - Postcard
 --- !u!4 &264953344
 Transform:
   m_ObjectHideFlags: 0
@@ -261582,6 +261583,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1820392072}
     m_Modifications:
+    - target: {fileID: 2686334892588053125, guid: c252e9b57effb6d49b0df765079fb9a7, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 3174206043724567575, guid: c252e9b57effb6d49b0df765079fb9a7, type: 3}
       propertyPath: ImageDisplay
       value: 
@@ -261594,6 +261599,22 @@ PrefabInstance:
       propertyPath: placeholderObject
       value: 
       objectReference: {fileID: 8578645253295158001, guid: 53b63535a81d5af45baa1b76920c5749, type: 3}
+    - target: {fileID: 3753946750515435909, guid: c252e9b57effb6d49b0df765079fb9a7, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 2761.8477
+      objectReference: {fileID: 0}
+    - target: {fileID: 3753946750515435909, guid: c252e9b57effb6d49b0df765079fb9a7, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 1862.655
+      objectReference: {fileID: 0}
+    - target: {fileID: 3753946750515435909, guid: c252e9b57effb6d49b0df765079fb9a7, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -87.956055
+      objectReference: {fileID: 0}
+    - target: {fileID: 3753946750515435909, guid: c252e9b57effb6d49b0df765079fb9a7, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 34.96469
+      objectReference: {fileID: 0}
     - target: {fileID: 5993240195274942701, guid: c252e9b57effb6d49b0df765079fb9a7, type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
@@ -261674,6 +261695,22 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6397581395307773876, guid: c252e9b57effb6d49b0df765079fb9a7, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 2775.0015
+      objectReference: {fileID: 0}
+    - target: {fileID: 6397581395307773876, guid: c252e9b57effb6d49b0df765079fb9a7, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 1879.0977
+      objectReference: {fileID: 0}
+    - target: {fileID: 6397581395307773876, guid: c252e9b57effb6d49b0df765079fb9a7, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -74.892456
+      objectReference: {fileID: 0}
+    - target: {fileID: 6397581395307773876, guid: c252e9b57effb6d49b0df765079fb9a7, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 46.608826
+      objectReference: {fileID: 0}
     - target: {fileID: 7690039836488619218, guid: c252e9b57effb6d49b0df765079fb9a7, type: 3}
       propertyPath: m_IsActive
       value: 1
@@ -261681,6 +261718,22 @@ PrefabInstance:
     - target: {fileID: 8009683466092053363, guid: c252e9b57effb6d49b0df765079fb9a7, type: 3}
       propertyPath: m_Name
       value: Minigames
+      objectReference: {fileID: 0}
+    - target: {fileID: 8453388848184868131, guid: c252e9b57effb6d49b0df765079fb9a7, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 2967.6646
+      objectReference: {fileID: 0}
+    - target: {fileID: 8453388848184868131, guid: c252e9b57effb6d49b0df765079fb9a7, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 1052.8848
+      objectReference: {fileID: 0}
+    - target: {fileID: 8453388848184868131, guid: c252e9b57effb6d49b0df765079fb9a7, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 933.1842
+      objectReference: {fileID: 0}
+    - target: {fileID: 8453388848184868131, guid: c252e9b57effb6d49b0df765079fb9a7, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -19.656982
       objectReference: {fileID: 0}
     - target: {fileID: 8971456928744567732, guid: c252e9b57effb6d49b0df765079fb9a7, type: 3}
       propertyPath: m_IsActive

--- a/Assets/Scripts/Menus/MainMenu.cs
+++ b/Assets/Scripts/Menus/MainMenu.cs
@@ -123,6 +123,6 @@ public class MainMenu : MonoBehaviour
     }
     public void Feedback()
     {
-        Application.OpenURL("https://oregonstate.qualtrics.com/jfe/form/SV_3IfO3l2H7FbOOuW");
+        Application.OpenURL("https://docs.google.com/forms/d/e/1FAIpQLScUSEfN_CHr3AmGCQ2JBpNjitt4-x1Rp-wycEEnlhHN-qIM1A/viewform?usp=header");
     }
 }

--- a/Assets/Scripts/Menus/MainMenu.cs
+++ b/Assets/Scripts/Menus/MainMenu.cs
@@ -54,10 +54,12 @@ public class MainMenu : MonoBehaviour
         PlayerPrefs.DeleteKey("ScoreCount");
         PlayerPrefs.DeleteKey("AiRivalScore");
         PlayerPrefs.DeleteKey("SpawnPointID");
+        
 
         PlayerPrefs.DeleteKey("hasShepardsGlasses");
         PlayerPrefs.DeleteKey("hasMedicalSupplies");
         PlayerPrefs.DeleteKey("hasIDCard");
+        PlayerPrefs.DeleteKey("hasPostcard");
 
         PlayerPrefs.Save();
 

--- a/Assets/Scripts/Menus/PauseMenu.cs
+++ b/Assets/Scripts/Menus/PauseMenu.cs
@@ -127,7 +127,7 @@ public class PauseMenu : MonoBehaviour
 
     public void Feedback()
     {
-        Application.OpenURL("https://oregonstate.qualtrics.com/jfe/form/SV_3IfO3l2H7FbOOuW");
+        Application.OpenURL("https://docs.google.com/forms/d/e/1FAIpQLScUSEfN_CHr3AmGCQ2JBpNjitt4-x1Rp-wycEEnlhHN-qIM1A/viewform?usp=header");
     }
 
     public void AdjustBrightness(float BrightnessValue)

--- a/Assets/Scripts/Menus/PauseMenu.cs
+++ b/Assets/Scripts/Menus/PauseMenu.cs
@@ -92,9 +92,6 @@ public class PauseMenu : MonoBehaviour
     public void SetVolume(float sliderValue)
     {
         SaveVolume(sliderValue);
-
-
-        //random comment because git is being finnicky and not letting me merge without new commits
         
         // Prevents math error in Mathf.Log10()
         if (sliderValue <= 0)

--- a/Assets/Scripts/Player/Minigames/CardMatchingMinigame.cs
+++ b/Assets/Scripts/Player/Minigames/CardMatchingMinigame.cs
@@ -232,10 +232,12 @@ public class CardMatchingMinigame : MonoBehaviour
             }
         }
     }
+
     public async Task CalculatePlay(string who)
     {
         bool wonRound = false;
-        if(questionCard.index == answerCard.index)  //cards match
+        if(questionCard.index == answerCard.index || answerCard.text.GetComponentInChildren<TextMeshProUGUI>().text
+         == questions[questionCard.index].options[questions[questionCard.index].answerIndex].text)  //cards match
         {
             wonRound = true;
 
@@ -382,12 +384,18 @@ public class CardMatchingMinigame : MonoBehaviour
         yield return new WaitUntil(() => pilot.gotQuestions);
         int count = Questioncards.Count;
         
-        
         for(int i = 0; i < count; i++) //get questions and answers from database
         {
             Question q = pilot.moduleManager.GetRandomQuestion(module, (int) (difficulty / 20));
-
-            questions[i] = q;
+            if(q.options[q.answerIndex].text.Contains("all") || q.options[q.answerIndex].text.Contains("All"))
+            {
+                i--; //redo this, do not add questions with the answer "all of the following" or alike
+            }
+            else
+            {
+                questions[i] = q;    
+            }
+            
         }
 
         List<int> remaining = new List<int>();

--- a/Assets/Scripts/Player/Minigames/MinigamePilot.cs
+++ b/Assets/Scripts/Player/Minigames/MinigamePilot.cs
@@ -40,22 +40,23 @@ public class MinigamePilot : MonoBehaviour
         CardForMatching matchcard = obj.GetComponent<CardForMatching>();
         CardForSlapping slapcard = obj.GetComponent<CardForSlapping>();
 
+        Debug.Log("BAD NAME: " + obj.gameObject.name);
         if (request.result == UnityWebRequest.Result.Success)
         {
             Texture2D texture = DownloadHandlerTexture.GetContent(request);
-            if (matchcard)
+            if (matchcard != null)
             {
                 matchcard.image.texture = texture;
             }
-            if (slapcard)
+            else if (slapcard != null)
             {
                 slapcard.image.texture = texture;
             }
             else //readerboard for wordbank
             {
-                obj.GetComponentInChildren<RawImage>().texture = texture;
+                Debug.Log("NAME: " + obj.gameObject.name);
+                obj.GetComponent<RawImage>().texture = texture;
             }
-            
         }
         else
         {

--- a/Assets/Scripts/Player/Minigames/MinigamePilot.cs
+++ b/Assets/Scripts/Player/Minigames/MinigamePilot.cs
@@ -1,7 +1,9 @@
 using UnityEngine;
+using UnityEngine.UI;
 using UnityEngine.Networking;
 using System.Collections;
 using System.Collections.Generic;
+using System.Reflection;
 
 public enum MinigameType
 {
@@ -30,13 +32,13 @@ public class MinigamePilot : MonoBehaviour
         gotQuestions = true;
 
     }
-    public IEnumerator DownloadImage(string url, GameObject card)
+    public IEnumerator DownloadImage(string url, GameObject obj)
     {
         // Use UnityWebRequestTexture to download raw image bytes directly
         UnityWebRequest request = UnityWebRequestTexture.GetTexture(url);
         yield return request.SendWebRequest();
-        CardForMatching matchcard = card.GetComponent<CardForMatching>();
-        CardForSlapping slapcard = card.GetComponent<CardForSlapping>();
+        CardForMatching matchcard = obj.GetComponent<CardForMatching>();
+        CardForSlapping slapcard = obj.GetComponent<CardForSlapping>();
 
         if (request.result == UnityWebRequest.Result.Success)
         {
@@ -48,6 +50,10 @@ public class MinigamePilot : MonoBehaviour
             if (slapcard)
             {
                 slapcard.image.texture = texture;
+            }
+            else //readerboard for wordbank
+            {
+                obj.GetComponentInChildren<RawImage>().texture = texture;
             }
             
         }

--- a/Assets/Scripts/Player/Minigames/SlapjackMinigame.cs
+++ b/Assets/Scripts/Player/Minigames/SlapjackMinigame.cs
@@ -254,12 +254,19 @@ public class SlapjackMinigame : MonoBehaviour
         yield return new WaitUntil(() => pilot.gotQuestions);
         
         int Questioncount = 10;
-        
     
         for(int i = 0; i < Questioncount; i++) //get questions and answers from database
         {
             Question q = pilot.moduleManager.GetRandomQuestion(module, (int) (difficulty / 20));
-            questions.Add(q);
+            if(q.options[q.answerIndex].text.Contains("all") || q.options[q.answerIndex].text.Contains("All"))
+            {
+                i--; //redo this, do not add questions with the answer "all of the following" or alike
+            }
+            else
+            {
+                questions.Add(q);  
+            }
+            
         }
 
         for(int i = 0; i < Questioncount; i++) //make new question cards and assign new questions

--- a/Assets/Scripts/Player/Minigames/WordBankMinigame.cs
+++ b/Assets/Scripts/Player/Minigames/WordBankMinigame.cs
@@ -385,10 +385,11 @@ public class WordBankMinigame : MonoBehaviour
             if(currentQuestion.imageLink != "")
             {
                 ImageDisplay.gameObject.SetActive(true);
-                StartCoroutine(pilot.DownloadImage(currentQuestion.imageLink, ImageDisplay.GetComponentInChildren<BoxCollider2D>(true).gameObject));
+                StartCoroutine(pilot.DownloadImage(currentQuestion.imageLink, ImageDisplay.gameObject));
             }
             else
             {
+                //Debug.Log("NOT, " + );
                 ImageDisplay.gameObject.SetActive(false);
             }
         }

--- a/Assets/Scripts/Player/Minigames/WordBankMinigame.cs
+++ b/Assets/Scripts/Player/Minigames/WordBankMinigame.cs
@@ -20,11 +20,15 @@ public class WordBankMinigame : MonoBehaviour
     public Transform sentenceOrigin; //starting point for sentence objects
     public List<Question> questions;
     public WordBankPlay awaiting = WordBankPlay.Arrange;
+
     public int numQuestions = 5;
 
     public Question currentQuestion;
+    public GameObject ImageDisplay;
     public List<WordFromBank> words = new List<WordFromBank>();
     public List<WordFromBank> answerSentence = new List<WordFromBank>(); //where you're putting them
+    public List<GameObject> placeholderObjects = new List<GameObject>(); //template squares to show how many words
+    public GameObject placeholderObject; //prefab for above
     public GameObject WordObject; //physical word to move around prefab
     public GameObject WordInHand; //object to lock to mouse/ finger position
     public int minigameDifficulty = 0; //separate from question difficulty (below)
@@ -48,7 +52,7 @@ public class WordBankMinigame : MonoBehaviour
     public TextMeshProUGUI yougavetext;
     public TextMeshProUGUI confusedtext;
     public GameObject lastQuestionInfo; //in info screen
-
+    public TextMeshProUGUI correctnessPopup; //"Correct!" or incorrect after guess that shows up for a few seconds
     public TextMeshProUGUI scorereader; //constant score reader
     public GameObject exitbutton; //closes game
     public GameObject infobutton;
@@ -66,6 +70,7 @@ public class WordBankMinigame : MonoBehaviour
         WordBank.SetActive(true);
         totalgainedcoins = 0; //reset session
         totalgainedpoints = 0;
+        questions.Clear();
         RestartPlay();
     }
     
@@ -110,6 +115,7 @@ public class WordBankMinigame : MonoBehaviour
         incorrectAnswers = 0;
 
         DeleteWords();
+        questions.Clear();
         StartCoroutine(getQuestionList());
         StartCoroutine(LoadWords());
 
@@ -128,9 +134,14 @@ public class WordBankMinigame : MonoBehaviour
         {
             Destroy(answerSentence[i].gameObject);
         }
+        for(int i = 0; i < placeholderObjects.Count; i++)
+        {
+            Destroy(placeholderObjects[i]);
+        }
 
         words.Clear();
         answerSentence.Clear();
+        placeholderObjects.Clear();
     }
     public void RandomizeWordAppearance()
     {
@@ -169,7 +180,10 @@ public class WordBankMinigame : MonoBehaviour
             numCoinsToGain++; //give a coin
             scorereader.text = "Correct Solutions: " + numCoinsToGain + "\nIncorrect Solutions: "
             + incorrectAnswers + "\nQuestions Left: " + questions.Count;
-
+            StopCoroutine(correctPopup(false));
+            StopCoroutine(correctPopup(true)); //halt if currently running;
+            
+            StartCoroutine(correctPopup(false));
         }
         else
         {
@@ -178,6 +192,10 @@ public class WordBankMinigame : MonoBehaviour
             incorrectAnswers++;
             scorereader.text = "Correct Solutions: " + numCoinsToGain + "\nIncorrect Solutions: "
             + incorrectAnswers + "\nQuestions Left: " + questions.Count;
+            StopCoroutine(correctPopup(false));
+            StopCoroutine(correctPopup(true)); //halt if currently running;
+
+            StartCoroutine(correctPopup(true));
         }
 
         updateLastQuestionTexts(sentence, currentQuestion.options[currentQuestion.answerIndex].text, currentQuestion.question);
@@ -239,6 +257,7 @@ public class WordBankMinigame : MonoBehaviour
         string currentWord = "";
         string rightAnswer = currentQuestion.options[currentQuestion.answerIndex].text;
         //iterate through to actually make the word objects and assign their values
+        //correct words
         for(int i = 0; i < rightAnswer.Length; i++) //size of string
         {
             if(rightAnswer[i] == ' ' || rightAnswer[i]  == '\n' || rightAnswer[i]  == '\r' || i == rightAnswer.Length - 1)
@@ -249,6 +268,14 @@ public class WordBankMinigame : MonoBehaviour
                 }
                 tempwords.Add(currentWord);
                 currentWord = "";
+
+                //make a placeholder in the sentence
+                int n = placeholderObjects.Count;
+                Vector2 position = new Vector2((sentenceOrigin.position.x + ((n * 140) % 840)) , 
+                (sentenceOrigin.position.y - ((n * 140) / 840) * 90)  );
+                GameObject placeholder = Instantiate(placeholderObject, position, Quaternion.identity);
+                placeholder.transform.SetParent(sentenceArea.transform, true);
+                placeholderObjects.Add(placeholder);
             }
             else
             {
@@ -264,9 +291,7 @@ public class WordBankMinigame : MonoBehaviour
         int numWordsInRightAnswer = tempwords.Count;
         for(int i = 0; i < minigameDifficulty * 3; i++)
         {
-            //will get the # of words in the correct answer * (the difficulty / 2)
-            //ie. difficulty 2 and a total size of 10 words in correct answer = 10 extra words
-            //difficulty 4 for the same question would be 20 extra words
+            //will get the # of words in the correct answer + (the difficulty * 3)
             randQ = pilot.randomQuestions[Random.Range(0,qtotal)]; //random Question
             int randO = Random.Range(0,randQ.options.Count);
 
@@ -299,8 +324,16 @@ public class WordBankMinigame : MonoBehaviour
                 }
             }
 
-            word = randWords[Random.Range(0, randWords.Count)];
-            tempwords.Add(word); //add to list
+            //try 3 different times to get a new word, else dont add one (adds variability)
+            for(int t = 0; t < 3; t++)
+            {
+                word = randWords[Random.Range(0, randWords.Count)];
+                if (!tempwords.Contains(word))
+                {
+                    tempwords.Add(word); //add to list
+                }
+            }
+            
 
             randWords.Clear();
         }
@@ -322,6 +355,24 @@ public class WordBankMinigame : MonoBehaviour
         RandomizeWordAppearance();
     }
 
+    public IEnumerator correctPopup(bool Incorrect)
+    {
+        correctnessPopup.gameObject.SetActive(true);
+        string toPrint = "";
+        if (Incorrect)
+        {
+            toPrint += "Inc";
+        }
+        else
+        {
+            toPrint += "C";
+        }
+        toPrint += "orrect!";
+        correctnessPopup.text = toPrint;
+        yield return new WaitForSeconds(4f);
+        correctnessPopup.text = "";
+        correctnessPopup.gameObject.SetActive(false);
+    }
     public void SelectNextQuestion()
     {
         if(questions.Count > 0)
@@ -330,14 +381,24 @@ public class WordBankMinigame : MonoBehaviour
             questions.RemoveAt(0);
 
             QuestionReader.GetComponentInChildren<TextMeshProUGUI>().text = currentQuestion.question;
+
+            if(currentQuestion.imageLink != "")
+            {
+                ImageDisplay.gameObject.SetActive(true);
+                StartCoroutine(pilot.DownloadImage(currentQuestion.imageLink, ImageDisplay.GetComponentInChildren<BoxCollider2D>(true).gameObject));
+            }
+            else
+            {
+                ImageDisplay.gameObject.SetActive(false);
+            }
         }
         else //game over
         {
+            ImageDisplay.gameObject.SetActive(false);
             OpenEndGamePopup();
             HandleCoinsandScore();
         }
     }
-
     public void HandleCoinsandScore()
     {
 
@@ -359,7 +420,6 @@ public class WordBankMinigame : MonoBehaviour
         }
         totalcointext.text = "That makes a total of:\n" + totalgainedcoins + " Coins and +" + totalgainedpoints + " Points"; 
     }
-
     public Vector2 getRandomGameboardPosition()
     {
         return new Vector2(Random.Range(-650f,650f), Random.Range(-325f,325f));

--- a/Assets/Scripts/Player/NPCController.cs
+++ b/Assets/Scripts/Player/NPCController.cs
@@ -73,10 +73,9 @@ public class NPCController : MonoBehaviour, Interactable
                 if (ProgressionState.Instance.HasItem(sceneTransitioner.NecessaryProgressionItemName))
                 {
                     int indexOfLevel = PlayerPrefs.GetInt("UnlockedLevel");
-
-                    if(sceneTransitioner.levelNumber == -1 && convertSpawnPointIDtoLevel(sceneTransitioner.targetSpawnPointID) < LevelManager.Instance.GetLevelNumberFromIndex(indexOfLevel))
+                    if(sceneTransitioner.levelNumber == -1 && convertSpawnPointIDtoLevel(sceneTransitioner.targetSpawnPointID) < indexOfLevel)
                     {
-                        Debug.Log("TEST: " + LevelManager.Instance.GetLevelNumberFromIndex(indexOfLevel));
+                        
                         //player has gotten past this MM level
                         willCharge = false;
                         StartCoroutine(DialogManager.Instance.ShowDialog(TravelIsFreeDialog, travelChoices, OnTravelChoiceSelected));

--- a/Assets/Scripts/Player/NPCSceneTransitioner.cs
+++ b/Assets/Scripts/Player/NPCSceneTransitioner.cs
@@ -7,7 +7,7 @@ using Unity.VisualScripting;
 public class NPCSceneTransitioner : MonoBehaviour
 {
     public int sceneBuildIndex; //for the destination level
-    public int levelNumber; //destination level
+    public int levelNumber; //destination level (-1 = murder mystery)
     public string targetSpawnPointID;
     private bool isTransitioning = false;       
     public int price = 0; //0 means it wont prompt for a price at all, as it is free


### PR DESCRIPTION
Applied:

-fix for items not saving correctly
-Fix for MM npcs not recognizing when mm was already solved (leading to always charging the player)
-Fixed hair for some npcs in level 2 which still had the default white hair

Minigame fixes that were rolled back:
-slapjack and card match had chance of questions with "all of the above" appearing, leading to confusion
-word bank now displays images
-word bank has placeholders to show number of words in correct answer
-word bank has a display above the enter button that more clearly indicates if the player got the question right