### PR TITLE
Level 4 NPCs

### DIFF
--- a/Assets/Scenes/Main Levels/Hub.unity
+++ b/Assets/Scenes/Main Levels/Hub.unity
@@ -325719,7 +325719,7 @@ PrefabInstance:
       objectReference: {fileID: 397287007}
     - target: {fileID: 3759062420398361793, guid: e3b3f787f063a39429f5463ae61140d5, type: 3}
       propertyPath: m_text
-      value: Version 2.3.1
+      value: Version 2.2.1
       objectReference: {fileID: 0}
     - target: {fileID: 4269122255798036399, guid: e3b3f787f063a39429f5463ae61140d5, type: 3}
       propertyPath: m_AnchorMax.y

--- a/Assets/Scenes/Main Levels/Hub.unity
+++ b/Assets/Scenes/Main Levels/Hub.unity
@@ -325719,7 +325719,7 @@ PrefabInstance:
       objectReference: {fileID: 397287007}
     - target: {fileID: 3759062420398361793, guid: e3b3f787f063a39429f5463ae61140d5, type: 3}
       propertyPath: m_text
-      value: Version 2.2.1
+      value: Version 2.3.1
       objectReference: {fileID: 0}
     - target: {fileID: 4269122255798036399, guid: e3b3f787f063a39429f5463ae61140d5, type: 3}
       propertyPath: m_AnchorMax.y

--- a/Assets/Scenes/Main Levels/Main Menu.unity
+++ b/Assets/Scenes/Main Levels/Main Menu.unity
@@ -1524,7 +1524,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Version 2.2.1
+  m_text: Version 2.3.1
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}

--- a/Assets/Scripts/Player/Murder Mystery/DetectiveController.cs
+++ b/Assets/Scripts/Player/Murder Mystery/DetectiveController.cs
@@ -134,11 +134,36 @@ public class DetectiveController : MonoBehaviour, Interactable
             autoClose: false
         ));
 
-         yield return StartCoroutine(DialogManager.Instance.ShowDialogText(
-            "You unlocked Level " + (murderCase.level + 1) + "!",
-            waitForInput: true,
-            autoClose: true
-        ));
+        //show unique dialogue when you complete the last murder mystery level
+        if((murderCase.level + 1) >= 5)
+        {
+            yield return StartCoroutine(DialogManager.Instance.ShowDialogText(
+                "You have completed all of our challenges for you! Congratulations!",
+                waitForInput: true,
+                autoClose: false
+            ));
+
+            yield return StartCoroutine(DialogManager.Instance.ShowDialogText(
+                "Dr. Shepard is thrilled to see how far you have come! You should be proud of yourself.",
+                waitForInput: true,
+                autoClose: false
+            ));
+
+            yield return StartCoroutine(DialogManager.Instance.ShowDialogText(
+                "You unlocked the bonus Organ Levels!",
+                waitForInput: true,
+                autoClose: true
+            ));
+        }
+        else
+        {
+            yield return StartCoroutine(DialogManager.Instance.ShowDialogText(
+                "You unlocked Level " + (murderCase.level + 1) + "!",
+                waitForInput: true,
+                autoClose: true
+            ));
+        }
+
 
         LevelManager.Instance.UnlockNextLevel();
 


### PR DESCRIPTION
Added many NPCs to Level 4, along with some minor assorted changes.

- added 15 static NPCs
- added 6 moving NPCs
- added 11 enemy NPCs
- Added the 3 NPCs for the minigames
- in total, I added 35 NPCs to level 4, more than any of the previous levels

additonally, i made a couple minor changes:
- added unique congratulatory dialogue when you complete the final murder mystery, as previously, it referenced a level 5 that will not exist.
- updated the version number within the game